### PR TITLE
Fix API doc formatting of examples in the  `responsiveSteps` property description

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -6,326 +6,17 @@
       "description": "",
       "summary": "",
       "sourceRange": {
-        "file": "vaadin-form-item.html",
+        "file": "vaadin-form-layout.html",
         "start": {
-          "line": 197,
+          "line": 430,
           "column": 6
         },
         "end": {
-          "line": 197,
+          "line": 430,
           "column": 42
         }
       },
       "elements": [
-        {
-          "description": "`<vaadin-form-layout>` is a Polymer 2 element providing configurable responsive\nlayout for form elements.\n\n```html\n<vaadin-form-layout>\n\n  <vaadin-form-item>\n    <label slot=\"label\">First Name</label>\n    <input class=\"full-width\" value=\"Jane\">\n  </vaadin-form-item>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Last Name</label>\n    <input class=\"full-width\" value=\"Doe\">\n  </vaadin-form-item>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Email</label>\n    <input class=\"full-width\" value=\"jane.doe@example.com\">\n  </vaadin-form-item>\n\n</vaadin-form-layout>\n```\n\nIt supports any child elements as layout items.\n\nBy default, it makes a layout of two columns if the element width is equal or\nwider than 40em, and a single column layout otherwise.\n\nThe number of columns and the responsive behavior are customizable with\nthe `responsiveSteps` property.\n\n### Spanning Items on Multiple Columns\n\nYou can use `colspan` attribute on the items.\nIn the example below, the first text field spans on two columns:\n\n```html\n<vaadin-form-layout>\n\n  <vaadin-form-item colspan=\"2\">\n    <label slot=\"label\">Address</label>\n    <input class=\"full-width\">\n  </vaadin-form-item>\n\n  <vaadin-form-item>\n    <label slot=\"label\">First Name</label>\n    <input class=\"full-width\" value=\"Jane\">\n  </vaadin-form-item>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Last Name</label>\n    <input class=\"full-width\" value=\"Doe\">\n  </vaadin-form-item>\n\n</vaadin-form-layout>\n```\n\n### Explicit New Row\n\nUse the `<br>` line break element to wrap the items on a new row:\n\n```html\n<vaadin-form-layout>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Email</label>\n    <input class=\"full-width\">\n  </vaadin-form-item>\n\n  <br>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Confirm Email</label>\n    <input class=\"full-width\">\n  </vaadin-form-item>\n\n</vaadin-form-layout>\n```\n\n### CSS Properties Reference\n\nThe following custom CSS properties are available on the `<vaadin-form-layout>`\nelement:\n\nCustom CSS property | Description | Default\n---|---|---\n`--vaadin-form-layout-column-gap` | Length of the gap between columns | `2em`",
-          "summary": "",
-          "path": "vaadin-form-layout.html",
-          "properties": [
-            {
-              "name": "responsiveSteps",
-              "type": "Array.<ResponsiveStep>",
-              "description": "Allows specifying a responsive behavior with the number of columns\nand the label position depending on the layout width.\n\nFormat: array of objects, each object defines one responsive step\nwith `minWidth` CSS length, `columns` number, and optional\n`labelsPosition` string of `\"aside\"` or `\"top\"`. At least one item is required.\n\n#### Examples\n\n<dl>\n  <dt>`[{columns: 1}]`</dt>\n  <dd>\n    <p>The layout is always a single column, labels aside.\n  </dd>\n\n  <dt><pre><code>[\n  {minWidth: 0, columns: 1},\n  {minWidth: '40em', columns: 2}\n]</code></pre></dt>\n  <dd>\n    <p>Sets two responsive steps:\n    <ol>\n      <li>When the layout width is < 40em, one column, labels aside.\n      <li>Width >= 40em, two columns, labels aside.\n    </ol>\n  </dd>\n\n  <dt><pre><code>[\n  {minWidth: 0, columns: 1, labelsPosition: 'top'},\n  {minWidth: '20em', columns: 1},\n  {minWidth: '40em', columns: 2}\n]</code></pre></dt>\n  <dd>\n    <p>Default value. Three responsive steps:\n    <ol>\n      <li>Width < 20em, one column, labels on top.\n      <li>20em <= width < 40em, one column, labels aside.\n      <li>Width >= 40em, two columns, labels aside.\n    </ol>\n  </dd>\n</dl>",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 225,
-                  "column": 12
-                },
-                "end": {
-                  "line": 235,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {
-                  "observer": "\"_responsiveStepsChanged\""
-                }
-              },
-              "defaultValue": "[]"
-            },
-            {
-              "name": "_columnCount",
-              "type": "number",
-              "description": "Current number of columns in the layout",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 240,
-                  "column": 12
-                },
-                "end": {
-                  "line": 242,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            },
-            {
-              "name": "_labelsOnTop",
-              "type": "boolean",
-              "description": "Indicates that labels are on top",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 247,
-                  "column": 12
-                },
-                "end": {
-                  "line": 249,
-                  "column": 13
-                }
-              },
-              "metadata": {
-                "polymer": {}
-              }
-            }
-          ],
-          "methods": [
-            {
-              "name": "ready",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 259,
-                  "column": 8
-                },
-                "end": {
-                  "line": 278,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "connectedCallback",
-              "description": "",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 280,
-                  "column": 8
-                },
-                "end": {
-                  "line": 285,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "_naturalNumberOrOne",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 287,
-                  "column": 8
-                },
-                "end": {
-                  "line": 290,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "n"
-                }
-              ]
-            },
-            {
-              "name": "_isValidCSSLength",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 292,
-                  "column": 8
-                },
-                "end": {
-                  "line": 314,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "value"
-                }
-              ]
-            },
-            {
-              "name": "_responsiveStepsChanged",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 316,
-                  "column": 8
-                },
-                "end": {
-                  "line": 354,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "responsiveSteps"
-                },
-                {
-                  "name": "oldResponsiveSteps"
-                }
-              ]
-            },
-            {
-              "name": "_selectResponsiveStep",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 356,
-                  "column": 8
-                },
-                "end": {
-                  "line": 379,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "_invokeUpdateStyles",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "start": {
-                  "line": 381,
-                  "column": 8
-                },
-                "end": {
-                  "line": 383,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": []
-            },
-            {
-              "name": "updateStyles",
-              "description": "Set custom CSS property values and update the layout.",
-              "privacy": "public",
-              "sourceRange": {
-                "start": {
-                  "line": 388,
-                  "column": 8
-                },
-                "end": {
-                  "line": 424,
-                  "column": 9
-                }
-              },
-              "metadata": {},
-              "params": [
-                {
-                  "name": "...args"
-                }
-              ]
-            }
-          ],
-          "staticMethods": [
-            {
-              "name": "constructor",
-              "description": "",
-              "privacy": "protected",
-              "sourceRange": {
-                "file": "bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
-                "start": {
-                  "line": 8,
-                  "column": 4
-                },
-                "end": {
-                  "line": 10,
-                  "column": 5
-                }
-              },
-              "metadata": {},
-              "params": [],
-              "inheritedFrom": "Vaadin.ThemableMixin"
-            }
-          ],
-          "demos": [
-            {
-              "url": "demo/index.html",
-              "description": ""
-            }
-          ],
-          "metadata": {},
-          "sourceRange": {
-            "start": {
-              "line": 159,
-              "column": 6
-            },
-            "end": {
-              "line": 425,
-              "column": 7
-            }
-          },
-          "privacy": "public",
-          "superclass": "HTMLElement",
-          "name": "Vaadin.FormLayoutElement",
-          "attributes": [
-            {
-              "name": "responsive-steps",
-              "description": "Allows specifying a responsive behavior with the number of columns\nand the label position depending on the layout width.\n\nFormat: array of objects, each object defines one responsive step\nwith `minWidth` CSS length, `columns` number, and optional\n`labelsPosition` string of `\"aside\"` or `\"top\"`. At least one item is required.\n\n#### Examples\n\n<dl>\n  <dt>`[{columns: 1}]`</dt>\n  <dd>\n    <p>The layout is always a single column, labels aside.\n  </dd>\n\n  <dt><pre><code>[\n  {minWidth: 0, columns: 1},\n  {minWidth: '40em', columns: 2}\n]</code></pre></dt>\n  <dd>\n    <p>Sets two responsive steps:\n    <ol>\n      <li>When the layout width is < 40em, one column, labels aside.\n      <li>Width >= 40em, two columns, labels aside.\n    </ol>\n  </dd>\n\n  <dt><pre><code>[\n  {minWidth: 0, columns: 1, labelsPosition: 'top'},\n  {minWidth: '20em', columns: 1},\n  {minWidth: '40em', columns: 2}\n]</code></pre></dt>\n  <dd>\n    <p>Default value. Three responsive steps:\n    <ol>\n      <li>Width < 20em, one column, labels on top.\n      <li>20em <= width < 40em, one column, labels aside.\n      <li>Width >= 40em, two columns, labels aside.\n    </ol>\n  </dd>\n</dl>",
-              "sourceRange": {
-                "start": {
-                  "line": 225,
-                  "column": 12
-                },
-                "end": {
-                  "line": 235,
-                  "column": 13
-                }
-              },
-              "metadata": {},
-              "type": "Array.<ResponsiveStep>"
-            }
-          ],
-          "events": [],
-          "styling": {
-            "cssVariables": [],
-            "selectors": []
-          },
-          "slots": [
-            {
-              "description": "",
-              "name": "",
-              "range": {
-                "file": "vaadin-form-layout.html",
-                "start": {
-                  "line": 59,
-                  "column": 6
-                },
-                "end": {
-                  "line": 59,
-                  "column": 29
-                }
-              }
-            }
-          ],
-          "tagname": "vaadin-form-layout",
-          "mixins": [
-            "Vaadin.ThemableMixin"
-          ]
-        },
         {
           "description": "`<vaadin-form-item>` is a Polymer 2 element providing labelled form item wrapper\nfor using inside `<vaadin-form-layout>`.\n\n`<vaadin-form-item>` accepts any number of children as the input content,\nand also has a separate named `label` slot:\n\n```html\n<vaadin-form-item>\n  <label slot=\"label\">Label aside</label>\n  <input>\n</vaadin-form-item>\n```\n\nAny content can be used. For instance, you can have multiple input elements\nwith surrounding text. The label can be an element of any type:\n\n```html\n<vaadin-form-item>\n  <span slot=\"label\">Date of Birth</span>\n  <input placeholder=\"YYYY\" size=\"4\"> -\n  <input placeholder=\"MM\" size=\"2\"> -\n  <input placeholder=\"DD\" size=\"2\"><br>\n  <em>Example: 1900-01-01</em>\n</vaadin-form-item>\n```\n\nThe label is optional and can be omitted:\n\n```html\n<vaadin-form-item>\n  <input type=\"checkbox\"> Subscribe to our Newsletter\n</vaadin-form-item>\n```\n\nBy default, the `label` slot content is displayed aside of the input content.\nWhen `label-position=\"top\"` is set, the `label` slot content is displayed on top:\n\n```html\n<vaadin-form-item label-position=\"top\">\n  <label slot=\"label\">Label on top</label>\n  <input>\n</vaadin-form-item>\n```\n\n**Note:** Normally, `<vaadin-form-item>` is used as a child of\na `<vaadin-form-layout>` element. Setting `label-position` is unnecessary,\nbecause the `label-position` attribute is triggered automatically by the parent\n`<vaadin-form-layout>`, depending on its width and responsive behavior.\n\n### Input Width\n\nBy default, `<vaadin-form-item>` does not manipulate the width of the slotted\ninput elements. Optionally you can stretch the child input element to fill\nthe available width for the input content by adding the `full-width` class:\n\n```html\n<vaadin-form-item>\n  <label slot=\"label\">Label</label>\n  <input class=\"full-width\">\n</vaadin-form-item>\n```\n\n### Styling\n\nThe `label-position` host attribute can be used to target the label on top state:\n\n<pre><code>\n&lt;dom-module id=\"my-form-item-theme\" theme-for=\"vaadin-form-item\"&gt;\n  &lt;template&gt;\n    &lt;style&gt;\n      :host {\n        /&#42; default state styles, label aside &#42;/\n      }\n\n      :host([label-position=\"top\"]) {\n        /&#42; label on top state styles &#42;/\n      }\n    &lt;/style&gt;\n  &lt;/template&gt;\n&lt;/dom-module&gt;\n</code></pre>\n\nThe following shadow DOM parts are available for styling:\n\nPart name | Description\n---|---\nlabel | The label slot container\n\n### Custom CSS Properties Reference\n\nThe following custom CSS properties are available on the `<vaadin-form-item>`\nelement:\n\nCustom CSS property | Description | Default\n---|---|---\n`--vaadin-form-item-label-width` | Width of the label column when the labels are aside | `8em`\n`--vaadin-form-item-label-gap` | Length of the gap between the label column and the input column when the labels are aside | `1em`\n`--vaadin-form-item-row-gap` | Height of the gap between the form item elements | `1em`",
           "summary": "",
@@ -356,22 +47,26 @@
           ],
           "staticMethods": [
             {
-              "name": "constructor",
+              "name": "_includeStyle",
               "description": "",
-              "privacy": "protected",
+              "privacy": "private",
               "sourceRange": {
                 "file": "bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
                 "start": {
-                  "line": 8,
+                  "line": 46,
                   "column": 4
                 },
                 "end": {
-                  "line": 10,
+                  "line": 50,
                   "column": 5
                 }
               },
               "metadata": {},
-              "params": [],
+              "params": [
+                {
+                  "name": "moduleName"
+                }
+              ],
               "inheritedFrom": "Vaadin.ThemableMixin"
             }
           ],
@@ -434,6 +129,319 @@
             }
           ],
           "tagname": "vaadin-form-item",
+          "mixins": [
+            "Vaadin.ThemableMixin"
+          ]
+        },
+        {
+          "description": "`<vaadin-form-layout>` is a Polymer 2 element providing configurable responsive\nlayout for form elements.\n\n```html\n<vaadin-form-layout>\n\n  <vaadin-form-item>\n    <label slot=\"label\">First Name</label>\n    <input class=\"full-width\" value=\"Jane\">\n  </vaadin-form-item>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Last Name</label>\n    <input class=\"full-width\" value=\"Doe\">\n  </vaadin-form-item>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Email</label>\n    <input class=\"full-width\" value=\"jane.doe@example.com\">\n  </vaadin-form-item>\n\n</vaadin-form-layout>\n```\n\nIt supports any child elements as layout items.\n\nBy default, it makes a layout of two columns if the element width is equal or\nwider than 40em, and a single column layout otherwise.\n\nThe number of columns and the responsive behavior are customizable with\nthe `responsiveSteps` property.\n\n### Spanning Items on Multiple Columns\n\nYou can use `colspan` attribute on the items.\nIn the example below, the first text field spans on two columns:\n\n```html\n<vaadin-form-layout>\n\n  <vaadin-form-item colspan=\"2\">\n    <label slot=\"label\">Address</label>\n    <input class=\"full-width\">\n  </vaadin-form-item>\n\n  <vaadin-form-item>\n    <label slot=\"label\">First Name</label>\n    <input class=\"full-width\" value=\"Jane\">\n  </vaadin-form-item>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Last Name</label>\n    <input class=\"full-width\" value=\"Doe\">\n  </vaadin-form-item>\n\n</vaadin-form-layout>\n```\n\n### Explicit New Row\n\nUse the `<br>` line break element to wrap the items on a new row:\n\n```html\n<vaadin-form-layout>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Email</label>\n    <input class=\"full-width\">\n  </vaadin-form-item>\n\n  <br>\n\n  <vaadin-form-item>\n    <label slot=\"label\">Confirm Email</label>\n    <input class=\"full-width\">\n  </vaadin-form-item>\n\n</vaadin-form-layout>\n```\n\n### CSS Properties Reference\n\nThe following custom CSS properties are available on the `<vaadin-form-layout>`\nelement:\n\nCustom CSS property | Description | Default\n---|---|---\n`--vaadin-form-layout-column-gap` | Length of the gap between columns | `2em`",
+          "summary": "",
+          "path": "vaadin-form-layout.html",
+          "properties": [
+            {
+              "name": "responsiveSteps",
+              "type": "Array.<ResponsiveStep>",
+              "description": "Allows specifying a responsive behavior with the number of columns\nand the label position depending on the layout width.\n\nFormat: array of objects, each object defines one responsive step\nwith `minWidth` CSS length, `columns` number, and optional\n`labelsPosition` string of `\"aside\"` or `\"top\"`. At least one item is required.\n\n#### Examples\n\n```javascript\nsplitLayout.responsiveSteps = [{columns: 1}];\n// The layout is always a single column, labels aside.\n```\n\n```javascript\nsplitLayout.responsiveSteps = [\n  {minWidth: 0, columns: 1},\n  {minWidth: '40em', columns: 2}\n];\n// Sets two responsive steps:\n// 1. When the layout width is < 40em, one column, labels aside.\n// 2. Width >= 40em, two columns, labels aside.\n```\n\n```javascript\nsplitLayout.responsiveSteps = [\n  {minWidth: 0, columns: 1, labelsPosition: 'top'},\n  {minWidth: '20em', columns: 1},\n  {minWidth: '40em', columns: 2}\n];\n// Default value. Three responsive steps:\n// 1. Width < 20em, one column, labels on top.\n// 2. 20em <= width < 40em, one column, labels aside.\n// 3. Width >= 40em, two columns, labels aside.\n```",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 219,
+                  "column": 12
+                },
+                "end": {
+                  "line": 229,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_responsiveStepsChanged\""
+                }
+              },
+              "defaultValue": "[]"
+            },
+            {
+              "name": "_columnCount",
+              "type": "number",
+              "description": "Current number of columns in the layout",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 234,
+                  "column": 12
+                },
+                "end": {
+                  "line": 236,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_labelsOnTop",
+              "type": "boolean",
+              "description": "Indicates that labels are on top",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 241,
+                  "column": 12
+                },
+                "end": {
+                  "line": 243,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            }
+          ],
+          "methods": [
+            {
+              "name": "ready",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 253,
+                  "column": 8
+                },
+                "end": {
+                  "line": 272,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "connectedCallback",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 274,
+                  "column": 8
+                },
+                "end": {
+                  "line": 279,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_naturalNumberOrOne",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 281,
+                  "column": 8
+                },
+                "end": {
+                  "line": 286,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "n"
+                }
+              ]
+            },
+            {
+              "name": "_isValidCSSLength",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 288,
+                  "column": 8
+                },
+                "end": {
+                  "line": 312,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ]
+            },
+            {
+              "name": "_responsiveStepsChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 314,
+                  "column": 8
+                },
+                "end": {
+                  "line": 352,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "responsiveSteps"
+                },
+                {
+                  "name": "oldResponsiveSteps"
+                }
+              ]
+            },
+            {
+              "name": "_selectResponsiveStep",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 354,
+                  "column": 8
+                },
+                "end": {
+                  "line": 377,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_invokeUpdateStyles",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 379,
+                  "column": 8
+                },
+                "end": {
+                  "line": 381,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "updateStyles",
+              "description": "Set custom CSS property values and update the layout.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 386,
+                  "column": 8
+                },
+                "end": {
+                  "line": 422,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "...args"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [
+            {
+              "name": "_includeStyle",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html",
+                "start": {
+                  "line": 46,
+                  "column": 4
+                },
+                "end": {
+                  "line": 50,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "moduleName"
+                }
+              ],
+              "inheritedFrom": "Vaadin.ThemableMixin"
+            }
+          ],
+          "demos": [
+            {
+              "url": "demo/index.html",
+              "description": ""
+            }
+          ],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 159,
+              "column": 6
+            },
+            "end": {
+              "line": 423,
+              "column": 7
+            }
+          },
+          "privacy": "public",
+          "superclass": "HTMLElement",
+          "name": "Vaadin.FormLayoutElement",
+          "attributes": [
+            {
+              "name": "responsive-steps",
+              "description": "Allows specifying a responsive behavior with the number of columns\nand the label position depending on the layout width.\n\nFormat: array of objects, each object defines one responsive step\nwith `minWidth` CSS length, `columns` number, and optional\n`labelsPosition` string of `\"aside\"` or `\"top\"`. At least one item is required.\n\n#### Examples\n\n```javascript\nsplitLayout.responsiveSteps = [{columns: 1}];\n// The layout is always a single column, labels aside.\n```\n\n```javascript\nsplitLayout.responsiveSteps = [\n  {minWidth: 0, columns: 1},\n  {minWidth: '40em', columns: 2}\n];\n// Sets two responsive steps:\n// 1. When the layout width is < 40em, one column, labels aside.\n// 2. Width >= 40em, two columns, labels aside.\n```\n\n```javascript\nsplitLayout.responsiveSteps = [\n  {minWidth: 0, columns: 1, labelsPosition: 'top'},\n  {minWidth: '20em', columns: 1},\n  {minWidth: '40em', columns: 2}\n];\n// Default value. Three responsive steps:\n// 1. Width < 20em, one column, labels on top.\n// 2. 20em <= width < 40em, one column, labels aside.\n// 3. Width >= 40em, two columns, labels aside.\n```",
+              "sourceRange": {
+                "start": {
+                  "line": 219,
+                  "column": 12
+                },
+                "end": {
+                  "line": 229,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "Array.<ResponsiveStep>"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [
+            {
+              "description": "",
+              "name": "",
+              "range": {
+                "file": "vaadin-form-layout.html",
+                "start": {
+                  "line": 59,
+                  "column": 6
+                },
+                "end": {
+                  "line": 59,
+                  "column": 29
+                }
+              }
+            }
+          ],
+          "tagname": "vaadin-form-layout",
           "mixins": [
             "Vaadin.ThemableMixin"
           ]

--- a/vaadin-form-layout.html
+++ b/vaadin-form-layout.html
@@ -188,38 +188,32 @@ This program is available under Apache License Version 2.0, available at https:/
              *
              * #### Examples
              *
-             * <dl>
-             *   <dt>`[{columns: 1}]`</dt>
-             *   <dd>
-             *     <p>The layout is always a single column, labels aside.
-             *   </dd>
+             * ```javascript
+             * splitLayout.responsiveSteps = [{columns: 1}];
+             * // The layout is always a single column, labels aside.
+             * ```
              *
-             *   <dt><pre><code>[
+             * ```javascript
+             * splitLayout.responsiveSteps = [
              *   {minWidth: 0, columns: 1},
              *   {minWidth: '40em', columns: 2}
-             * ]</code></pre></dt>
-             *   <dd>
-             *     <p>Sets two responsive steps:
-             *     <ol>
-             *       <li>When the layout width is < 40em, one column, labels aside.
-             *       <li>Width >= 40em, two columns, labels aside.
-             *     </ol>
-             *   </dd>
+             * ];
+             * // Sets two responsive steps:
+             * // 1. When the layout width is < 40em, one column, labels aside.
+             * // 2. Width >= 40em, two columns, labels aside.
+             * ```
              *
-             *   <dt><pre><code>[
+             * ```javascript
+             * splitLayout.responsiveSteps = [
              *   {minWidth: 0, columns: 1, labelsPosition: 'top'},
              *   {minWidth: '20em', columns: 1},
              *   {minWidth: '40em', columns: 2}
-             * ]</code></pre></dt>
-             *   <dd>
-             *     <p>Default value. Three responsive steps:
-             *     <ol>
-             *       <li>Width < 20em, one column, labels on top.
-             *       <li>20em <= width < 40em, one column, labels aside.
-             *       <li>Width >= 40em, two columns, labels aside.
-             *     </ol>
-             *   </dd>
-             * </dl>
+             * ];
+             * // Default value. Three responsive steps:
+             * // 1. Width < 20em, one column, labels on top.
+             * // 2. 20em <= width < 40em, one column, labels aside.
+             * // 3. Width >= 40em, two columns, labels aside.
+             * ```
              *
              * @type {ResponsiveStep[]}
              */


### PR DESCRIPTION
### Before
![screen shot 2017-10-25 at 14 53 42](https://user-images.githubusercontent.com/247998/31997452-ad1129fe-b994-11e7-9d73-613a2624158e.png)

### After
![screen shot 2017-10-25 at 14 53 58](https://user-images.githubusercontent.com/247998/31997455-ad344286-b994-11e7-8ea7-dc54a36d58e3.png)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-form-layout/48)
<!-- Reviewable:end -->
