### PR TITLE
Fix css style checking for safari9

### DIFF
--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -311,7 +311,8 @@ This program is available under Apache License Version 2.0, available at https:/
             return true;
           }
 
-          return this._styleElement.sheet.cssRules[0].style.getPropertyValue('word-spacing') !== '';
+          // Safari 9 sets invalid CSS rules' value to `null`
+          return ['', null].indexOf(this._styleElement.sheet.cssRules[0].style.getPropertyValue('word-spacing')) < 0;
         }
 
         _responsiveStepsChanged(responsiveSteps, oldResponsiveSteps) {


### PR DESCRIPTION
Safari 9 returns null when css value is set as "10"
https://github.com/vaadin/vaadin-form-layout/blob/master/test/form-layout.html#L225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-form-layout/65)
<!-- Reviewable:end -->
