### PR TITLE
Remove explicit width from the br

### DIFF
--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -52,7 +52,6 @@ This program is available under Apache License Version 2.0, available at https:/
         display: block;
         content: '';
         flex: 1 1 100%;
-        width: 9999px; /* for Firefox :-( */
       }
     </style>
     <div id="layout">

--- a/test/form-layout.html
+++ b/test/form-layout.html
@@ -34,6 +34,19 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="flex-child">
+    <template>
+      <div style="display: flex">
+        <div>Foo</div>
+        <vaadin-form-layout>
+          <vaadin-text-field></vaadin-text-field>
+          <br>
+          <vaadin-text-field></vaadin-text-field>
+        </vaadin-form-layout>
+      </div>
+    </template>
+  </test-fixture>
+
   <test-fixture id="overflow">
     <template>
       <div style="width: 300px; overflow: auto;">
@@ -397,6 +410,22 @@
           });
         });
       });
+    });
+
+    describe('flex child', function() {
+      let container, layout;
+
+      beforeEach(() => {
+        container = fixture('flex-child');
+        layout = container.querySelector('vaadin-form-layout');
+      });
+
+      it('should have less width than then flexbox', () => {
+        const containerRect = container.getBoundingClientRect();
+        const layoutRect = layout.getBoundingClientRect();
+        expect(layoutRect.width).to.be.below(containerRect.width);
+      });
+
     });
   </script>
 </body>


### PR DESCRIPTION
Fixes #78

Debugged this with @platosha and apparently the explicit "9999px" hack for Firefox (that causes the issue) is no longer required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-form-layout/79)
<!-- Reviewable:end -->
