### PR TITLE
Update Material theme: set font-family on the label part

### DIFF
--- a/theme/material/vaadin-form-item-styles.html
+++ b/theme/material/vaadin-form-item-styles.html
@@ -5,6 +5,7 @@
   <template>
     <style>
       [part="label"] {
+        font-family: var(--material-font-family);
         font-size: var(--material-small-font-size);
         color: var(--material-secondary-text-color);
         line-height: 16px;


### PR DESCRIPTION
Align with the Lumo theme which sets the value for the `font-family` as well as other font CSS properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-form-layout/87)
<!-- Reviewable:end -->
