### PR TITLE
fix: Safari 12 rendering issue

### DIFF
--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -24,7 +24,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       @keyframes vaadin-form-layout-appear {
         to {
-          opacity: 1;
+          opacity: 1 !important; /* stylelint-disable-line keyframe-declaration-no-important */
         }
       }
 


### PR DESCRIPTION
A CSS animation used to detect element rendering (by triggering an animation event) was triggering a weird rendering bug in Safari 12 where elements would sometimes be shown in wildly incorrect positions. This is now fixed.

Fixes #110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-form-layout/112)
<!-- Reviewable:end -->
