### PR TITLE
Update calcs for line breaks

### DIFF
--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -463,21 +463,21 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           let col = 0;
-          Array.from(this.children).forEach((child, index) => {
-            if (child.localName === 'br') {
-              // Reset column count on line break
-              col = 0;
-            } else if (getComputedStyle(child).display !== 'none') {
-              const followingVisibleItems = Array.from(this.children)
-                .slice(index + 1)
-                .filter(item => item.localName === 'br' || getComputedStyle(item).display !== 'none');
+          Array.from(this.children)
+            .filter(child => child.localName === 'br' || getComputedStyle(child).display !== 'none')
+            .forEach((child, index, children) => {
+              if (child.localName === 'br') {
+                // Reset column count on line break
+                col = 0;
+                return;
+              }
 
-              const nextLineBreak = followingVisibleItems.length > 0 &&
-                followingVisibleItems[0].localName === 'br';
+              const nextIndex = index + 1;
+              const nextLineBreak = nextIndex < children.length && children[nextIndex].localName === 'br';
 
               if (nextLineBreak) {
                 const colspanRatio = (this._columnCount - col - 1) / this._columnCount;
-                child.style.paddingRight = `calc(${colspanRatio * containerWidth}px + ${colspanRatio} * ${columnSpacing})`;
+                child.style.setProperty(marginEndProp, `calc(${colspanRatio * containerWidth}px + ${colspanRatio} * ${columnSpacing})`);
               }
 
               let colspan;
@@ -505,9 +505,9 @@ This program is available under Apache License Version 2.0, available at https:/
               }
 
               // At the end edge
-              if (nextLineBreak || col + colspan === this._columnCount) {
+              if (col + colspan === this._columnCount) {
                 child.style.setProperty(marginEndProp, '0px');
-              } else {
+              } else if (!nextLineBreak) {
                 child.style.removeProperty(marginEndProp);
               }
 
@@ -521,8 +521,7 @@ This program is available under Apache License Version 2.0, available at https:/
                   child.removeAttribute('label-position');
                 }
               }
-            }
-          });
+            });
         }
       }
 

--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -472,14 +472,6 @@ This program is available under Apache License Version 2.0, available at https:/
                 return;
               }
 
-              const nextIndex = index + 1;
-              const nextLineBreak = nextIndex < children.length && children[nextIndex].localName === 'br';
-
-              if (nextLineBreak) {
-                const colspanRatio = (this._columnCount - col - 1) / this._columnCount;
-                child.style.setProperty(marginEndProp, `calc(${colspanRatio * containerWidth}px + ${colspanRatio} * ${columnSpacing})`);
-              }
-
               let colspan;
               colspan = this._naturalNumberOrOne(parseFloat(child.getAttribute('colspan')));
 
@@ -495,6 +487,14 @@ This program is available under Apache License Version 2.0, available at https:/
               if (col + colspan > this._columnCount) {
                 // Too big to fit on this row, let’s wrap it
                 col = 0;
+              }
+
+              const nextIndex = index + 1;
+              const nextLineBreak = nextIndex < children.length && children[nextIndex].localName === 'br';
+
+              if (nextLineBreak) {
+                const colspanRatio = (this._columnCount - col - colspan) / this._columnCount;
+                child.style.setProperty(marginEndProp, `calc(${colspanRatio * containerWidth}px + ${colspanRatio} * ${columnSpacing})`);
               }
 
               // At the start edge

--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -49,17 +49,6 @@ This program is available under Apache License Version 2.0, available at https:/
         margin-left: calc(0.5 * var(--vaadin-form-layout-column-spacing));
         margin-right: calc(0.5 * var(--vaadin-form-layout-column-spacing));
       }
-
-      #layout ::slotted(br) {
-        /*
-          Line break element wraps the following item on a new line. Makes
-          a block with zero height, stretched to fill all the available width
-          of layout, so that the next sibling item is wrapped for sure.
-        */
-        display: block;
-        content: '';
-        flex: 1 1 100%;
-      }
     </style>
     <div id="layout">
       <slot id="slot"></slot>
@@ -470,29 +459,37 @@ This program is available under Apache License Version 2.0, available at https:/
           }
 
           let col = 0;
-          Array.from(this.children).forEach((child) => {
+          Array.from(this.children).forEach((child, index) => {
             if (getComputedStyle(child).display !== 'none') {
-              let colspan;
-
               if (child.localName === 'br') {
-                colspan = this._columnCount - col;
-              } else {
-                colspan = this._naturalNumberOrOne(parseFloat(child.getAttribute('colspan')));
-
-                // Never span further than the number of columns
-                colspan = Math.min(colspan, this._columnCount);
+                // Reset column count on line break
+                col = 0;
+                return;
               }
+
+              const followingVisibleItems = Array.from(this.children)
+                .slice(index + 1)
+                .filter(item => getComputedStyle(item).display !== 'none');
+
+              const nextLineBreak = followingVisibleItems.length > 0 &&
+                followingVisibleItems[0].localName === 'br';
+
+              if (nextLineBreak) {
+                const colspanRatio = (this._columnCount - col - 1) / this._columnCount;
+                child.style.paddingRight = `calc(${colspanRatio * containerWidth}px + ${colspanRatio} * ${columnSpacing})`;
+              }
+
+              let colspan;
+              colspan = this._naturalNumberOrOne(parseFloat(child.getAttribute('colspan')));
+
+              // Never span further than the number of columns
+              colspan = Math.min(colspan, this._columnCount);
 
               const childRatio = colspan / this._columnCount;
 
-              if (child.localName === 'br') {
-                // IE and Edge only accept fixed padding
-                child.style.paddingRight = `calc(${childRatio * containerWidth}px - ${1 - childRatio} * ${columnSpacing})`;
-              } else {
-                // Note: using 99.9% for 100% fixes rounding errors in MS Edge
-                // (< v16), otherwise the items might wrap, resizing is wobbly.
-                child.style.width = `calc(${childRatio * 99.9}% - ${1 - childRatio} * ${columnSpacing})`;
-              }
+              // Note: using 99.9% for 100% fixes rounding errors in MS Edge
+              // (< v16), otherwise the items might wrap, resizing is wobbly.
+              child.style.width = `calc(${childRatio * 99.9}% - ${1 - childRatio} * ${columnSpacing})`;
 
               if (col + colspan > this._columnCount) {
                 // Too big to fit on this row, let’s wrap it
@@ -507,7 +504,7 @@ This program is available under Apache License Version 2.0, available at https:/
               }
 
               // At the end edge
-              if (col + colspan === this._columnCount) {
+              if (nextLineBreak || col + colspan === this._columnCount) {
                 child.style.setProperty(marginEndProp, '0px');
               } else {
                 child.style.removeProperty(marginEndProp);

--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -489,13 +489,6 @@ This program is available under Apache License Version 2.0, available at https:/
                 col = 0;
               }
 
-              const nextIndex = index + 1;
-              const nextLineBreak = nextIndex < children.length && children[nextIndex].localName === 'br';
-
-              if (nextLineBreak) {
-                const colspanRatio = (this._columnCount - col - colspan) / this._columnCount;
-                child.style.setProperty(marginEndProp, `calc(${colspanRatio * containerWidth}px + ${colspanRatio} * ${columnSpacing})`);
-              }
 
               // At the start edge
               if (col === 0) {
@@ -504,10 +497,16 @@ This program is available under Apache License Version 2.0, available at https:/
                 child.style.removeProperty(marginStartProp);
               }
 
+              const nextIndex = index + 1;
+              const nextLineBreak = nextIndex < children.length && children[nextIndex].localName === 'br';
+
               // At the end edge
               if (col + colspan === this._columnCount) {
                 child.style.setProperty(marginEndProp, '0px');
-              } else if (!nextLineBreak) {
+              } else if (nextLineBreak) {
+                const colspanRatio = (this._columnCount - col - colspan) / this._columnCount;
+                child.style.setProperty(marginEndProp, `calc(${colspanRatio * containerWidth}px + ${colspanRatio} * ${columnSpacing})`);
+              } else {
                 child.style.removeProperty(marginEndProp);
               }
 

--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -49,6 +49,10 @@ This program is available under Apache License Version 2.0, available at https:/
         margin-left: calc(0.5 * var(--vaadin-form-layout-column-spacing));
         margin-right: calc(0.5 * var(--vaadin-form-layout-column-spacing));
       }
+
+      #layout ::slotted(br) {
+        display: none;
+      }
     </style>
     <div id="layout">
       <slot id="slot"></slot>
@@ -460,16 +464,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
           let col = 0;
           Array.from(this.children).forEach((child, index) => {
-            if (getComputedStyle(child).display !== 'none') {
-              if (child.localName === 'br') {
-                // Reset column count on line break
-                col = 0;
-                return;
-              }
-
+            if (child.localName === 'br') {
+              // Reset column count on line break
+              col = 0;
+            } else if (getComputedStyle(child).display !== 'none') {
               const followingVisibleItems = Array.from(this.children)
                 .slice(index + 1)
-                .filter(item => getComputedStyle(item).display !== 'none');
+                .filter(item => item.localName === 'br' || getComputedStyle(item).display !== 'none');
 
               const nextLineBreak = followingVisibleItems.length > 0 &&
                 followingVisibleItems[0].localName === 'br';

--- a/test/form-layout.html
+++ b/test/form-layout.html
@@ -58,7 +58,7 @@
           <div at-end>3 end</div>
           <br>
           <div style="display: none;">invisible</div>
-          <div at-start="">4 start</div>
+          <div at-start="" colspan="2">4 start</div>
           <div style="display: none;">invisible</div>
           <br>
           <div at-start>5 start</div>
@@ -427,6 +427,12 @@
 
       it('should not overflow containers horizontally', () => {
         expect(container.scrollWidth).to.equal(container.clientWidth);
+      });
+
+      it('should maintain the colspan value before the line break', () => {
+        const secondItemRect = layout.children[1].getBoundingClientRect();
+        const fourthItemRect = layout.children[5].getBoundingClientRect();
+        expect(secondItemRect.right).to.be.closeTo(fourthItemRect.right, .5);
       });
 
       describe('no spacing on edges', () => {

--- a/test/form-layout.html
+++ b/test/form-layout.html
@@ -59,6 +59,7 @@
           <br>
           <div style="display: none;">invisible</div>
           <div at-start="">4 start</div>
+          <div style="display: none;">invisible</div>
           <br>
           <div at-start>5 start</div>
           <div colspan="2" at-end>6 end</div>


### PR DESCRIPTION
Edge 18 does not apply any styles to line break elements.
The logic is now changed to check if the next visible item is `<br>` and apply appropriate `padding`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-form-layout/114)
<!-- Reviewable:end -->
