### PR TITLE
feat: prepare for TS defs generation

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,0 +1,7 @@
+export type FormLayoutLabelsPosition = 'aside' | 'top';
+
+export type FormLayoutResponsiveStep = {
+  minWidth?: string | 0;
+  columns: number;
+  labelsPosition?: FormLayoutLabelsPosition;
+};

--- a/bower.json
+++ b/bower.json
@@ -29,10 +29,10 @@
   "dependencies": {
     "iron-resizable-behavior": "^2.0.0",
     "polymer": "^2.0.0",
-    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.2.1",
+    "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.6.0",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.3.2",
-    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.3.0"
+    "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^2.4.1"
   },
   "devDependencies": {
     "iron-component-page": "^3.0.0",
@@ -44,8 +44,5 @@
     "web-component-tester": "^6.1.5",
     "vaadin-demo-helpers": "vaadin/vaadin-demo-helpers#^3.1.0",
     "vaadin-ordered-layout": "vaadin/vaadin-ordered-layout#^1.3.0"
-  },
-  "resolutions": {
-    "vaadin-element-mixin": "^2.3.0"
   }
 }

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -1,0 +1,14 @@
+{
+  "excludeFiles": [
+    "wct.conf.js",
+    "index.html",
+    "demo/**/*",
+    "test/**/*",
+    "theme/**/*"
+  ],
+  "autoImport": {
+    "./@types/interfaces": [
+      "FormLayoutResponsiveStep"
+    ]
+  }
+}

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,12 @@
+module.exports = {
+  files: [
+    'vaadin-form-item.js',
+    'vaadin-form-layout.js'
+  ],
+  from: [
+    /import '\.\/theme\/lumo\/vaadin-(.+)\.js';/
+  ],
+  to: [
+    `import './theme/lumo/vaadin-$1.js';\nexport * from './src/vaadin-$1.js';`
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
   },
   "homepage": "https://vaadin.com/components",
   "files": [
+    "vaadin-*.d.ts",
     "vaadin-*.js",
+    "@types",
     "src",
     "theme"
   ],

--- a/src/vaadin-form-item.html
+++ b/src/vaadin-form-item.html
@@ -183,6 +183,7 @@ This program is available under Apache License Version 2.0, available at https:/
           };
         }
 
+        /** @private */
         _onLabelClick(e) {
           // No `Array.prototype.find` in MSIE, using `filter` instead :-(
           const firstContentElementChild = Array.prototype.filter.call(

--- a/src/vaadin-form-layout.html
+++ b/src/vaadin-form-layout.html
@@ -172,7 +172,7 @@ This program is available under Apache License Version 2.0, available at https:/
         static get properties() {
           return {
             /**
-             * @typedef ResponsiveStep
+             * @typedef FormLayoutResponsiveStep
              * @type {object}
              * @property {string} minWidth - The threshold value for this step in CSS length units.
              * @property {number} columns - Number of columns. Only natural numbers are valid.
@@ -216,7 +216,7 @@ This program is available under Apache License Version 2.0, available at https:/
              * // 3. Width >= 40em, two columns, labels aside.
              * ```
              *
-             * @type {ResponsiveStep[]}
+             * @type {!Array<!FormLayoutResponsiveStep>}
              */
             responsiveSteps: {
               type: Array,
@@ -232,6 +232,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Current number of columns in the layout
+             * @private
              */
             _columnCount: {
               type: Number
@@ -239,6 +240,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Indicates that labels are on top
+             * @private
              */
             _labelsOnTop: {
               type: Boolean
@@ -252,6 +254,7 @@ This program is available under Apache License Version 2.0, available at https:/
           ];
         }
 
+        /** @protected */
         ready() {
           // Here we create and attach a style element that we use for validating
           // CSS values in `responsiveSteps`. We can’t add this to the `<template>`,
@@ -274,6 +277,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.addEventListener('animationend', this.__onAnimationEnd);
         }
 
+        /** @protected */
         connectedCallback() {
           super.connectedCallback();
 
@@ -283,6 +287,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this._observeChildrenColspanChange();
         }
 
+        /** @protected */
         disconnectedCallback() {
           super.disconnectedCallback();
 
@@ -290,6 +295,7 @@ This program is available under Apache License Version 2.0, available at https:/
           this.__childObserver.disconnect();
         }
 
+        /** @private */
         _observeChildrenColspanChange() {
           // Observe changes in form items' `colspan` attribute and update styles
           const mutationObserverConfig = {attributes: true};
@@ -318,12 +324,14 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
 
+        /** @private */
         _getObservableNodes(nodeList) {
           const ignore = ['template', 'style', 'dom-repeat', 'dom-if'];
           return Array.from(nodeList)
             .filter(node => node.nodeType === Node.ELEMENT_NODE && ignore.indexOf(node.localName.toLowerCase()) === -1);
         }
 
+        /** @private */
         _naturalNumberOrOne(n) {
           if (typeof n === 'number' && n >= 1 && n < Infinity) {
             return Math.floor(n);
@@ -331,6 +339,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return 1;
         }
 
+        /** @private */
         _isValidCSSLength(value) {
           // Let us choose a CSS property for validating CSS <length> values:
           // - `border-spacing` accepts `<length> | inherit`, it’s the best! But
@@ -358,6 +367,7 @@ This program is available under Apache License Version 2.0, available at https:/
           return ['', null].indexOf(this._styleElement.sheet.cssRules[0].style.getPropertyValue('word-spacing')) < 0;
         }
 
+        /** @private */
         _responsiveStepsChanged(responsiveSteps, oldResponsiveSteps) {
           try {
             if (!Array.isArray(responsiveSteps)) {
@@ -398,12 +408,14 @@ This program is available under Apache License Version 2.0, available at https:/
           this._selectResponsiveStep();
         }
 
+        /** @private */
         __onAnimationEnd(e) {
           if (e.animationName.indexOf('vaadin-form-layout-appear') === 0) {
             this._selectResponsiveStep();
           }
         }
 
+        /** @private */
         _selectResponsiveStep() {
           // Iterate through responsiveSteps and choose the step
           let selectedStep;
@@ -436,15 +448,18 @@ This program is available under Apache License Version 2.0, available at https:/
           }
         }
 
+        /** @private */
         _invokeUpdateStyles() {
           this.updateStyles();
         }
 
         /**
          * Set custom CSS property values and update the layout.
+         * @param {Object<string, string>=} properties
+         * @protected
          */
-        updateStyles(...args) {
-          super.updateStyles(...args);
+        updateStyles(properties) {
+          super.updateStyles(properties);
 
           /*
             The item width formula:


### PR DESCRIPTION
Fixes #126 

Generated TS definitions look like this:

### `vaadin-form-item.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

declare class FormItemElement extends
  ThemableMixin(
  PolymerElement) {
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-form-item": FormItemElement;
  }
}

export {FormItemElement};
```

### `vaadin-form-layout.d.ts`

```ts
import {PolymerElement} from '@polymer/polymer/polymer-element.js';

import {FlattenedNodesObserver} from '@polymer/polymer/lib/utils/flattened-nodes-observer.js';

import {IronResizableBehavior} from '@polymer/iron-resizable-behavior/iron-resizable-behavior.js';

import {ThemableMixin} from '@vaadin/vaadin-themable-mixin/vaadin-themable-mixin.js';

import {ElementMixin} from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';

import {html} from '@polymer/polymer/lib/utils/html-tag.js';

import {beforeNextRender} from '@polymer/polymer/lib/utils/render-status.js';

import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';

declare class FormLayoutElement extends
  ElementMixin(
  ThemableMixin(
  PolymerElement)) {

  responsiveSteps: FormLayoutResponsiveStep[];

  ready(): void;
  connectedCallback(): void;
  disconnectedCallback(): void;
  updateStyles(properties?: {[key: string]: string}): void;
}

declare global {
  interface HTMLElementTagNameMap {
    "vaadin-form-layout": FormLayoutElement;
  }
}

export {FormLayoutElement};

import {FormLayoutResponsiveStep} from '../@types/interfaces';
```

### `@types/interfaces.d.ts`

```ts
export type FormLayoutLabelsPosition = 'aside' | 'top';

export type FormLayoutResponsiveStep = {
  minWidth?: string | 0;
  columns: number;
  labelsPosition?: FormLayoutLabelsPosition;
};
```